### PR TITLE
[header.memory.synop] Fix entry for weak_ptr

### DIFF
--- a/memory.html
+++ b/memory.html
@@ -80,7 +80,7 @@ namespace std {
     template&lt;class E, class T, class Y>
       basic_ostream&lt;E, T>& operator&lt;&lt; (basic_ostream&lt;E, T>& os, const shared_ptr&lt;Y>& p);
 
-    // <cxx-ref in="cxx" to="util.smartptr.weak"></cxx-ref>
+    <cxx-ref insynopsis="" to="memory.smartptr.weak"></cxx-ref>
     template&lt;class T> class weak_ptr;
 
     // <cxx-ref in="cxx" to="util.smartptr.weak.spec"></cxx-ref>


### PR DESCRIPTION
It should reference [memory.smartptr.weak] in the TS rather than C++14.
