### PR TITLE
 [optional.object.observe] add missing constexpr

### DIFF
--- a/optional.html
+++ b/optional.html
@@ -582,7 +582,7 @@ constexpr optional(optional&lt;U&gt;&amp;&amp; rhs);</cxx-signature>
       </cxx-function>
 
       <cxx-function>
-        <cxx-signature>template &lt;class U&gt; T value_or(U&amp;&amp; <var>v</var>) &amp;&amp;;</cxx-signature>
+        <cxx-signature>template &lt;class U&gt; constexpr T value_or(U&amp;&amp; <var>v</var>) &amp;&amp;;</cxx-signature>
 
         <cxx-effects>Equivalent to <code>return bool(*this) ? <w-br></w-br>std::move(**this) : <w-br></w-br>static_cast&lt;T&gt;(std::forward&lt;U&gt;(<var>v</var>));</code></cxx-effects>
         <cxx-remarks>If <code>is_move_constructible_v&lt;T&gt; &amp;&amp; <w-br></w-br>is_convertible_v&lt;U&amp;&amp;, T&gt;</code> is <code>false</code>,


### PR DESCRIPTION
This change is present in [N4078](http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2014/n4078.html), but for some reason was missed when [N4078 was applied](https://github.com/cplusplus/fundamentals-ts/commit/7b47f9c82d38cef42a07933376f0319eceff9a21). See also cplusplus/draft#839
