### PR TITLE
[general.plans] Relax future plans, remove "every year".

### DIFF
--- a/fundamentals-ts.html
+++ b/fundamentals-ts.html
@@ -1670,8 +1670,8 @@ html   [segment], html   segment {
     this technical specification and plans for moving content into
     future versions of the C++ Standard.</p>
 
-    <p id="general.plans.2" para_num="2">The C++ committee intends to release a new version of this
-    technical specification approximately every year, containing the
+    <p id="general.plans.2" para_num="2">The C++ committee intends to release new versions of this
+    technical specification periodically, containing the
     library extensions we hope to add to a near-future version of the
     C++ Standard. Future versions will define their contents in
     <code>std::experimental::fundamentals_v4</code>,

--- a/general.html
+++ b/general.html
@@ -142,8 +142,8 @@
     this technical specification and plans for moving content into
     future versions of the C++ Standard.</p>
 
-    <p>The C++ committee intends to release a new version of this
-    technical specification approximately every year, containing the
+    <p>The C++ committee intends to release new versions of this
+    technical specification periodically, containing the
     library extensions we hope to add to a near-future version of the
     C++ Standard. Future versions will define their contents in
     <code>std::experimental::fundamentals_v4</code>,


### PR DESCRIPTION
The committee's current practice does not result in a new TS every
year and is unlikely to do so anytime soon.

This change has been discussed with the LEWG and LWG chairs and on the reflector. The affected wording is not normative, but all the same, it should express an agreed-upon position.