### PR TITLE
Missing change for `memory_resource`

### DIFF
--- a/mods.html
+++ b/mods.html
@@ -72,7 +72,7 @@
         using constructor arguments <code>v1, v2, ..., vN</code> of types <code>V1, V2, ..., VN</code>, respectively,
         and an allocator <code>alloc</code> of type <code>Alloc</code>,
         <ins>where <code>Alloc</code> either (1) meets the requirements of an allocator (<cxx-ref in="cxx" to="allocator.requirements"></cxx-ref>),
-        or (2) is a pointer type convertible to <code>std::experimental::pmr::memory_resource*</code> (<cxx-ref to="memory.resource"></cxx-ref>),</ins>
+        or (2) is a pointer type convertible to <code>std::pmr::memory_resource*</code> (<cxx-ref to="memory.resource"></cxx-ref>),</ins>
         according to the following rules:
       </p>
     </blockquote>

--- a/mods.html
+++ b/mods.html
@@ -72,7 +72,7 @@
         using constructor arguments <code>v1, v2, ..., vN</code> of types <code>V1, V2, ..., VN</code>, respectively,
         and an allocator <code>alloc</code> of type <code>Alloc</code>,
         <ins>where <code>Alloc</code> either (1) meets the requirements of an allocator (<cxx-ref in="cxx" to="allocator.requirements"></cxx-ref>),
-        or (2) is a pointer type convertible to <code>std::pmr::memory_resource*</code> (<cxx-ref to="memory.resource"></cxx-ref>),</ins>
+        or (2) is a pointer type convertible to <code>std::pmr::memory_resource*</code> (<cxx-ref in="cxx" to="mem.res"></cxx-ref>),</ins>
         according to the following rules:
       </p>
     </blockquote>


### PR DESCRIPTION
There's no `std::experimental::pmr::memory_resource` in LFTS v3. `std::pmr::memory_resource` should be used.