### PR TITLE
[scopeguard.uniqueres.assign] Add missing "Returns:" element.

### DIFF
--- a/fundamentals-ts.html
+++ b/fundamentals-ts.html
@@ -4069,7 +4069,12 @@ execute_on_reset = exchange(rhs.execute_on_reset, false);</code></pre>
           </dd>
   </cxx-effects>
 
-          <cxx-throws id="scopeguard.uniqueres.assign.4" para_num="4">
+          <cxx-returns id="scopeguard.uniqueres.assign.4" para_num="4">
+    
+    <dt>Returns:</dt><dd><code>*this</code>.</dd>
+  </cxx-returns>
+
+          <cxx-throws id="scopeguard.uniqueres.assign.5" para_num="5">
     
     <dt>Throws:</dt><dd>
             Any exception thrown during a copy-assignment of a member that
@@ -4077,7 +4082,7 @@ execute_on_reset = exchange(rhs.execute_on_reset, false);</code></pre>
           </dd>
   </cxx-throws>
 
-          <cxx-remarks id="scopeguard.uniqueres.assign.5" para_num="5">
+          <cxx-remarks id="scopeguard.uniqueres.assign.6" para_num="6">
     
     <dt>Remarks:</dt><dd>
             The expression inside <code>noexcept</code> is equivalent to:

--- a/utilities.html
+++ b/utilities.html
@@ -1245,6 +1245,8 @@ execute_on_reset = exchange(rhs.execute_on_reset, false);</code></pre>
             </cxx-note>
           </cxx-effects>
 
+          <cxx-returns><code>*this</code>.</cxx-returns>
+
           <cxx-throws>
             Any exception thrown during a copy-assignment of a member that
             cannot be moved without an exception.


### PR DESCRIPTION
A "Returns: *this" element is clearly intended here, but was missing in the original proposal P0052R10.