### PR TITLE
Update func.html

### DIFF
--- a/func.html
+++ b/func.html
@@ -18,12 +18,6 @@ namespace std {
 
     template&lt;class R, class... ArgTypes&gt;
     bool operator==(const function&lt;R(ArgTypes...)&gt;&amp;, nullptr_t) noexcept;
-    template&lt;class R, class... ArgTypes&gt;
-    bool operator==(nullptr_t, const function&lt;R(ArgTypes...)&gt;&amp;) noexcept;
-    template&lt;class R, class... ArgTypes&gt;
-    bool operator!=(const function&lt;R(ArgTypes...)&gt;&amp;, nullptr_t) noexcept;
-    template&lt;class R, class... ArgTypes&gt;
-    bool operator!=(nullptr_t, const function&lt;R(ArgTypes...)&gt;&amp;) noexcept;
 
   } // namespace experimental::inline fundamentals_v3
 
@@ -96,19 +90,6 @@ namespace std {
 
       pmr::memory_resource* get_memory_resource() const noexcept;
     };
-
-    template &lt;class R, class... ArgTypes&gt;
-    bool operator==(const function&lt;R(ArgTypes...)&gt;&amp;, nullptr_t) noexcept;
-    template &lt;class R, class... ArgTypes&gt;
-    bool operator==(nullptr_t, const function&lt;R(ArgTypes...)&gt;&amp;) noexcept;
-
-    template &lt;class R, class... ArgTypes&gt;
-    bool operator!=(const function&lt;R(ArgTypes...)&gt;&amp;, nullptr_t) noexcept;
-    template &lt;class R, class... ArgTypes&gt;
-    bool operator!=(nullptr_t, const function&lt;R(ArgTypes...)&gt;&amp;) noexcept;
-
-    template &lt;class R, class... ArgTypes&gt;
-    void swap(function&lt;R(ArgTypes...)&gt;&amp;, function&lt;R(ArgTypes...)&gt;&amp;);
 
   } // namespace experimental::inline fundamentals_v3
 


### PR DESCRIPTION
Remove the redundant overloads of `operator==` that have been struck from C++20.  For further simplicity, this follows the convention fully enforced in C++23 that the functions declared in the header synopsis are not repeated below the class definition.

I believe this change to be editorial, as we explicitly reference C++20 for the specification here, so this is just aligning to match up the declarations, there are no normative wording changes.