### PR TITLE
Remove binders typedefs from `function`

### DIFF
--- a/func.html
+++ b/func.html
@@ -56,9 +56,6 @@ namespace std {
     class function&lt;R(ArgTypes...)&gt; {
     public:
       using result_type = R;
-      using argument_type = T1;
-      using first_argument_type T1;
-      using second_argument_type = T2;
 
       using allocator_type = erased_type;
 


### PR DESCRIPTION
To sync up with the C++20 specification for `function`, remove the typedefs for the legacy binders API that were excised by C++20.

LWG chair may wish to open an LWG Issue first, as the change is observable compared to LFTS 2, but the change is fundamentally editorial in aligning the specification of `function` to the standard it refers to, so I am trying my luck!