### PR TITLE
[introduction, general] An "Introduction" clause.

### DIFF
--- a/fundamentals-ts.html
+++ b/fundamentals-ts.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- Sources at https://github.com/cplusplus/fundamentals-ts -->
-<html lang="en"><head><!--[if lte IE 8]><script>document.createElement("nav");document.createElement("section");document.createElement("time");document.createElement("CXX-TITLEPAGE");document.createElement("CXX-DOCNUM");document.createElement("CXX-REVISES");document.createElement("CXX-EDITOR");document.createElement("CXX-EMAIL");document.createElement("CXX-TOC");document.createElement("CXX-CLAUSE");document.createElement("CXX-REF");document.createElement("CXX-FOREIGN-INDEX");document.createElement("CXX-SECTION");document.createElement("CXX-EXAMPLE");document.createElement("CXX-NOTE");document.createElement("CXX-FUNCTION");document.createElement("CXX-SIGNATURE");document.createElement("CXX-CONSTRAINTS");document.createElement("CXX-EFFECTS");document.createElement("CXX-RETURNS");document.createElement("CXX-PRECONDITIONS");document.createElement("CXX-REMARKS");document.createElement("CXX-MANDATES");document.createElement("CXX-17CONCEPT");document.createElement("CXX-THROWS");document.createElement("CXX-POSTCONDITIONS");document.createElement("CXX-TERM");document.createElement("W-BR");document.createElement("CXX-COMPLEXITY");document.createElement("CXX-PUBLISH-BUTTON");</script><![endif]--><style>template {display: none !important;} /* injected by platform.js */</style><style>body {transition: opacity ease-in 0.2s; }
+<html lang="en"><head><!--[if lte IE 8]><script>document.createElement("nav");document.createElement("section");document.createElement("time");document.createElement("CXX-TITLEPAGE");document.createElement("CXX-DOCNUM");document.createElement("CXX-REVISES");document.createElement("CXX-EDITOR");document.createElement("CXX-EMAIL");document.createElement("CXX-TOC");document.createElement("CXX-CLAUSE");document.createElement("CXX-TERM");document.createElement("CXX-REF");document.createElement("CXX-FOREIGN-INDEX");document.createElement("CXX-SECTION");document.createElement("CXX-EXAMPLE");document.createElement("CXX-NOTE");document.createElement("CXX-FUNCTION");document.createElement("CXX-SIGNATURE");document.createElement("CXX-CONSTRAINTS");document.createElement("CXX-EFFECTS");document.createElement("CXX-RETURNS");document.createElement("CXX-PRECONDITIONS");document.createElement("CXX-REMARKS");document.createElement("CXX-MANDATES");document.createElement("CXX-17CONCEPT");document.createElement("CXX-THROWS");document.createElement("CXX-POSTCONDITIONS");document.createElement("W-BR");document.createElement("CXX-COMPLEXITY");document.createElement("CXX-PUBLISH-BUTTON");</script><![endif]--><style>template {display: none !important;} /* injected by platform.js */</style><style>body {transition: opacity ease-in 0.2s; }
 body[unresolved] {opacity: 0; display: block; overflow: hidden; position: relative; }
 </style><style shim-shadowdom-css="">style { display: none !important; }
 cxx-function {
@@ -1062,6 +1062,10 @@ html   [segment], html   segment {
 
           <ol>
 
+              <li><a href="#introduction">Introduction</a>
+
+      </li>
+
               <li><span class="marker">1</span><a href="#general.scope">Scope</a>
 
       </li>
@@ -1459,7 +1463,32 @@ html   [segment], html   segment {
   <li>[to be provided]</li>
 </ul>
 </cxx-foreword -->
-<cxx-clause id="general.scope">
+<cxx-clause id="introduction" number="none">
+
+
+    <section>
+      <header><span class="section-number"></span> <h1 data-bookmark-label=" Introduction">Introduction</h1> <span style="float:right"><a href="#introduction">[introduction]</a></span></header>
+
+
+
+  <p id="introduction.1" para_num="1">
+    In this document, the phrase <cxx-term><i>C++ Standard Library</i></cxx-term>
+    refers to the library described in ISO/IEC 14882:2020 clauses 16–32.
+  </p>
+
+  <p id="introduction.2" para_num="2">
+    Clauses and subclauses in this document are annotated with a so-called stable name,
+    presented in square brackets next to the (sub)clause heading
+    (such as "[introduction]" for this clause).
+    Stable names aid in the discussion and evolution of this document
+    by serving as stable references to subclauses across editions
+    that are unaffected by changes of subclause numbering.
+  </p>
+
+    </section>
+  </cxx-clause>
+
+<cxx-clause id="general.scope" number="1">
 
 
     <section>
@@ -1527,20 +1556,6 @@ html   [segment], html   segment {
     <li>ISO Online browsing platform: available at <a href="https://www.iso.org/obp">https://www.iso.org/obp</a></li>
     <li>IEC Electropedia: available at <a href="https://www.electropedia.org/">https://www.electropedia.org/</a></li>
   </ul>
-
-  <dl is="cxx-definition-section">
-
-
-
-    <dt id="defns.stdlib">
-    3.1
-    <span style="float:right"><a href="#defns.stdlib">[defns.stdlib]</a></span>
-    <br clear="all">
-    C++ Standard Library
-  </dt>
-    <dd>the library described in ISO/IEC 14882:2020 clauses 16–32</dd>
-
-  </dl>
 
     </section>
   </cxx-clause>

--- a/general.html
+++ b/general.html
@@ -1,4 +1,22 @@
-<cxx-clause id="general.scope">
+<cxx-clause id="introduction" number="none">
+  <h1>Introduction</h1>
+
+  <p>
+    In this document, the phrase <cxx-term>C++ Standard Library</cxx-term>
+    refers to the library described in ISO/IEC 14882:2020 clauses 16–32.
+  </p>
+
+  <p>
+    Clauses and subclauses in this document are annotated with a so-called stable name,
+    presented in square brackets next to the (sub)clause heading
+    (such as "[introduction]" for this clause).
+    Stable names aid in the discussion and evolution of this document
+    by serving as stable references to subclauses across editions
+    that are unaffected by changes of subclause numbering.
+  </p>
+</cxx-clause>
+
+<cxx-clause id="general.scope" number="1">
   <h1>Scope</h1>
   <p>This document describes extensions to the C++
   Standard Library (<cxx-ref to="general.references"></cxx-ref>).
@@ -47,11 +65,6 @@
     <li>ISO Online browsing platform: available at <a href="https://www.iso.org/obp">https://www.iso.org/obp</a></li>
     <li>IEC Electropedia: available at <a href="https://www.electropedia.org/">https://www.electropedia.org/</a></li>
   </ul>
-
-  <dl is="cxx-definition-section">
-    <dt id="defns.stdlib">C++ Standard Library</dt>
-    <dd>the library described in ISO/IEC 14882:2020 clauses 16–32</dd>
-  </dl>
 </cxx-clause>
 
 <cxx-clause id="general">


### PR DESCRIPTION
The "Introduction" clause contains an explanation of our use of stable names, and the definition of "C++ Standard Library", both of which where requested by ISO.

ISO said that "["C++ Standard Library"] is not a definition". They leave it up to us where to put this text, and since they also requested an explanation of stable names in the Introduction clause, that seemed a fitting place for both.